### PR TITLE
Server side callbacks

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -32,7 +32,7 @@ valid_path <- function(routes, path) {
 #' @param ui Valid Shiny user interface.
 #' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {
-  server <- if(exists("server")) {
+  server <- if (is.function(server)) {
               server
             } else {
               function(input, output) {}

--- a/R/router.R
+++ b/R/router.R
@@ -33,9 +33,9 @@ valid_path <- function(routes, path) {
 #' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {
   server <- if(exists("server")) {
-              function(input, output) {}
-            } else {
               server
+            } else {
+              function(input, output) {}
             }
 
   out <- list()

--- a/R/router.R
+++ b/R/router.R
@@ -32,6 +32,12 @@ valid_path <- function(routes, path) {
 #' @param ui Valid Shiny user interface.
 #' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {
+  server <- if(is.na(server)) {
+              function(input, output) {}
+            } else {
+              server
+            }
+
   out <- list()
   out[["ui"]] <- ui
   out[["server"]] <- server

--- a/R/router.R
+++ b/R/router.R
@@ -79,8 +79,10 @@ create_router_callback <- function(root, routes) {
       initialize_router()
       location <- input[[HIDDEN_ROUTE_INPUT]]
       if (valid_path(routes, location)) {
+        routes[[location]][["server"]](input, output)
         routes[[location]][["ui"]]
       } else {
+        routes[[root]][["server"]](input, output)
         routes[[root]][["ui"]]
       }
     })

--- a/R/router.R
+++ b/R/router.R
@@ -28,6 +28,7 @@ valid_path <- function(routes, path) {
 
 #' Create a mapping bewtween a ui element
 #' and a server callack
+#'
 #' @param ui Valid Shiny user interface.
 #' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {

--- a/R/router.R
+++ b/R/router.R
@@ -26,19 +26,27 @@ valid_path <- function(routes, path) {
   (!is.null(path) && path %in% names(routes))
 }
 
+callback_mapping <- function(ui, server = NA) {
+  out <- list()
+  out[["ui"]] <- ui
+  out[["server"]] <- server
+  out
+}
+
 #' Create single route configuration.
 #'
 #' @param path Website route.
 #' @param ui Valid Shiny user interface.
+#' @param server Function that is called as callback on server side
 #' @return A route configuration.
 #' @examples
 #' route("/", shiny::tags$div(shiny::tags$span("Hello world")))
 #'
 #' route("/main", div(h1("Main page"), p("Lorem ipsum.")))
 #' @export
-route <- function(path, ui) {
+route <- function(path, ui, server = NA) {
   out <- list()
-  out[[path]] <- ui
+  out[[path]] <- callback_mapping(ui, server)
   out
 }
 
@@ -71,9 +79,9 @@ create_router_callback <- function(root, routes) {
       initialize_router()
       location <- input[[HIDDEN_ROUTE_INPUT]]
       if (valid_path(routes, location)) {
-        routes[[location]]
+        routes[[location]][["ui"]]
       } else {
-        routes[[root]]
+        routes[[root]][["ui"]]
       }
     })
   }

--- a/R/router.R
+++ b/R/router.R
@@ -26,6 +26,10 @@ valid_path <- function(routes, path) {
   (!is.null(path) && path %in% names(routes))
 }
 
+#' Create a mapping bewtween a ui element
+#' and a server callack
+#' @param ui Valid Shiny user interface.
+#' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {
   out <- list()
   out[["ui"]] <- ui

--- a/R/router.R
+++ b/R/router.R
@@ -32,7 +32,7 @@ valid_path <- function(routes, path) {
 #' @param ui Valid Shiny user interface.
 #' @param server Function that is called within the global server function if given
 callback_mapping <- function(ui, server = NA) {
-  server <- if(is.na(server)) {
+  server <- if(exists("server")) {
               function(input, output) {}
             } else {
               server

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -5,7 +5,8 @@ library(shiny.router)
 menu <- (
   tags$ul(
     tags$li(a(class = "item", href = "/", "Page")),
-    tags$li(a(class = "item", href = "/other", "Other page"))
+    tags$li(a(class = "item", href = "/other", "Other page")),
+    tags$li(a(class = "item", href = "/third", "A third page"))
   )
 )
 
@@ -41,7 +42,8 @@ other_callback <- function(input, output) {
 # well as a server-side callback for each page.
 router <- make_router(
   route("/", root_page, root_callback),
-  route("/other", other_page, other_callback)
+  route("/other", other_page, other_callback),
+  route("/third", other_page, NA)
 )
 
 # Creat output for our router in main UI of Shiny app.

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -14,7 +14,8 @@ page <- function(title, content) {
   div(
     menu,
     titlePanel(title),
-    p(content)
+    p(content),
+    dataTableOutput("table")
   )
 }
 
@@ -22,10 +23,25 @@ page <- function(title, content) {
 root_page <- page("Home page", "Welcome on sample routing page!")
 other_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
 
-# Creates router. We provide routing path and UI for this page.
+# Callbacks on the server side for
+# the sample pages
+root_callback <- function(input, output) {
+  output$table <- renderDataTable({
+    data.frame(x = c(1, 2), y = c(3, 4))
+  })
+}
+
+other_callback <- function(input, output) {
+  output$table <- renderDataTable({
+    data.frame(x = c(5, 6), y = c(7, 8))
+  })
+}
+
+# Creates router. We provide routing path, a UI as
+# well as a server-side callback for each page.
 router <- make_router(
-  route("/", root_page),
-  route("/other", other_page)
+  route("/", root_page, root_callback),
+  route("/other", other_page, other_callback)
 )
 
 # Creat output for our router in main UI of Shiny app.


### PR DESCRIPTION
Hi 👋 First of all: Thanks for your work on the `shiny.router` package!

This PR is intended as a question. For the shiny applications that I wrote at work I needed a simple routing layer that affects both, the UI elements as well as the server-side computations for the corresponding datasets. 

If I got everything correct, `shiny.router` currently manipulates only the UI layer of the shiny application. That means, the data crunching computations within the global `server` function were not touched by the routing, so currently there is no option to "redefine" them explicitly.

My questions is: Should this be possible? I'm not sure if I know enough of the overall project and situation to judge, I was just driven by my personal needs: When I constructed my applications it feels like it makes sense to define different server functions for different endpoints. So therefore I experimented with it resulting in these changes. 

Is this a direction you'd like to embrace or is this outside your planned scope of `shiny.router`? Since I'm also not 100% confident about the technical details of my approach I'd be happy to get your feedback!