### PR TITLE
Allow passing common value for each server callback

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -9,7 +9,7 @@ callback_mapping <- function(ui, server = NA) {
   server <- if (is.function(server)) {
               server
             } else {
-              function(input, output, session) {}
+              function(input, output, session, ...) {}
             }
   out <- list()
   out[["ui"]] <- ui
@@ -41,7 +41,7 @@ route <- function(path, ui, server = NA) {
 #' @param routes A routes (list).
 #' @return Router callback.
 create_router_callback <- function(root, routes) {
-  function(input, output, session = shiny::getDefaultReactiveDomain()) {
+  function(input, output, session = shiny::getDefaultReactiveDomain(), ...) {
     # Making this a list inside a shiny::reactiveVal, instead of using a
     # shiny::reactiveValues, because it should change atomically.
     log_msg("Creating current_page reactive...")
@@ -102,7 +102,7 @@ create_router_callback <- function(root, routes) {
     # Switch the displayed page, if the path changes.
     output[[ROUTER_UI_ID]] <- shiny::renderUI({
       log_msg("shiny.router main output. path: ", session$userData$shiny.router.page()$path)
-      routes[[session$userData$shiny.router.page()$path]][["server"]](input, output, session)
+      routes[[session$userData$shiny.router.page()$path]][["server"]](input, output, session, ...)
       routes[[session$userData$shiny.router.page()$path]][["ui"]]
     })
   }

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -26,13 +26,13 @@ other_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur a
 
 # Callbacks on the server side for
 # the sample pages
-root_callback <- function(input, output, session, oko) {
+root_callback <- function(input, output, session) {
   output$table <- renderDataTable({
     data.frame(x = c(1, 2), y = c(3, 4))
   })
 }
 
-other_callback <- function(input, output, session, oko) {
+other_callback <- function(input, output, session) {
   output$table <- renderDataTable({
     data.frame(x = c(5, 6), y = c(7, 8))
   })

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -26,13 +26,13 @@ other_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur a
 
 # Callbacks on the server side for
 # the sample pages
-root_callback <- function(input, output, session) {
+root_callback <- function(input, output, session, oko) {
   output$table <- renderDataTable({
     data.frame(x = c(1, 2), y = c(3, 4))
   })
 }
 
-other_callback <- function(input, output, session) {
+other_callback <- function(input, output, session, oko) {
   output$table <- renderDataTable({
     data.frame(x = c(5, 6), y = c(7, 8))
   })
@@ -52,8 +52,8 @@ ui <- shinyUI(fluidPage(
 ))
 
 # Plug router into Shiny server.
-server <- shinyServer(function(input, output) {
-  router(input, output)
+server <- shinyServer(function(input, output, session) {
+  router(input, output, session)
 })
 
 # Run server in a standard way.

--- a/examples/common_server_parameter.R
+++ b/examples/common_server_parameter.R
@@ -1,0 +1,72 @@
+library(shiny)
+library(shiny.router)
+
+# This generates menu in user interface with links.
+menu <- (
+  tags$ul(
+    tags$li(a(class = "item", href = route_link("/"), "Page")),
+    tags$li(a(class = "item", href = route_link("second"), "Second page"))
+  )
+)
+
+# This creates UI for each page.
+page <- function(title, content) {
+  div(
+    menu,
+    titlePanel(title),
+    p(content),
+    textOutput("server_own_counter"),
+    textOutput("server_common_counter")
+  )
+}
+
+# Both sample pages.
+root_page <- page("Home page", "Welcome on sample routing page!")
+second_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+
+# Callbacks on the server side for
+# the sample pages
+root_callback <- function(input, output, session, value) {
+  output$server_own_counter <- renderText({
+    as.numeric(input$clicks_separate) ^ 2
+  })
+  output$server_common_counter <- renderText({
+    as.numeric(value())
+  })
+}
+
+second_callback <- function(input, output, session, value) {
+  output$server_own_counter <- renderText({
+    as.numeric(input$clicks_separate) ^ 3
+  })
+  output$server_common_counter <- renderText({
+    as.numeric(value())
+  })
+}
+
+# Creates router. We provide routing path, a UI as
+# well as a server-side callback for each page.
+router <- make_router(
+  route("/", root_page, root_callback),
+  route("second", second_page, second_callback)
+)
+
+# Creat output for our router in main UI of Shiny app.
+ui <- shinyUI(fluidPage(
+  shiny::actionButton("clicks_separate", "Each server counts me differently!"),
+  shiny::actionButton("clicks_common", "My counter is passed to both servers!"),
+  router_ui()
+))
+
+# Plug router into Shiny server.
+server <- shinyServer(function(input, output, session) {
+  common_counter <- reactive({
+    input$clicks_common
+  })
+
+  router(input, output, session, value = common_counter)
+
+})
+
+# Run server in a standard way.
+shinyApp(ui, server)

--- a/examples/common_server_parameter.R
+++ b/examples/common_server_parameter.R
@@ -53,8 +53,8 @@ router <- make_router(
 
 # Creat output for our router in main UI of Shiny app.
 ui <- shinyUI(fluidPage(
-  shiny::actionButton("clicks_separate", "Each server counts me differently!"),
-  shiny::actionButton("clicks_common", "My counter is passed to both servers!"),
+  shiny::actionButton("clicks_separate", "Each router callback counts me differently!"),
+  shiny::actionButton("clicks_common", "My counter is passed to both router callbacks!"),
   router_ui()
 ))
 

--- a/man/make_router.Rd
+++ b/man/make_router.Rd
@@ -23,6 +23,7 @@ Creates router. Returned callback needs to be called within Shiny server code.
 router <- make_router(
   route("/", root_page),
   route("/other", other_page),
-  page_404 = page404(message404 = "Please check if you passed correct bookmark name!")
+  page_404 = page404(
+    message404 = "Please check if you passed correct bookmark name!")
 )
 }


### PR DESCRIPTION
The current solution for using server callback didn't allow using common reactive or non-reactive objects.
This forced us to define them in each server callback (duplicated code). This simple change solves the problem.