### PR TITLE
Use relative path when creating router link.

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -51,7 +51,7 @@ extract_link_name <- function(path) {
 #' @examples
 #' route_link("abc") # /#!/abc
 route_link <- function(path) {
-  paste0("/", cleanup_hashpath(path))
+  paste0("./", cleanup_hashpath(path))
 }
 
 ########################### To export

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -4,7 +4,7 @@ library(shiny.router)
 # This generates menu in user interface with links.
 menu <- (
   tags$ul(
-    tags$li(a(class = "item", href = "/", "Page")),
+    tags$li(a(class = "item", href = route_link("/"), "Page")),
     tags$li(a(class = "item", href = route_link("other"), "Other page")),
     tags$li(a(class = "item", href = route_link("third"), "A third page"))
   )

--- a/examples/get_params.R
+++ b/examples/get_params.R
@@ -5,7 +5,7 @@ options(shiny.router.debug = T)
 # This generates menu in user interface with links.
 menu <- (
   tags$ul(
-    tags$li(a(class = "item", href = "/", "Page")),
+    tags$li(a(class = "item", href = route_link("/"), "Page")),
     tags$li(a(class = "item", href = route_link("other"), "Other page"))
   )
 )

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -13,8 +13,8 @@ test_that("test extract_link_name", {
 })
 
 test_that("test route_link", {
-  expect_equal(route_link("abc"), "/#!/abc")
-  expect_equal(route_link("#/xyzq"), "/#!/xyzq")
+  expect_equal(route_link("abc"), "./#!/abc")
+  expect_equal(route_link("#/xyzq"), "./#!/xyzq")
 })
 
 test_that("test parse_url_path", {
@@ -26,5 +26,3 @@ test_that("test parse_url_path", {
   expect_true(length(p$query$b) == 2)
   expect_equal(p$query$b[[2]], "bar")
 })
-
-


### PR DESCRIPTION
# Use relative path when creating a router link.
Use relative path for the apps not hosted on the top domain. For example shinyapps, multi apps in the same domain. Reference to an issue #56 

For the reviewer:
Is any case that we need the absolute path in router link? We can add param for creating an absolute or relative path.