### PR TITLE
Add support for urls with query strings proceeding hashbang

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -88,6 +88,7 @@ parse_url_path <- function(url_path) {
   url_has_hash <- url_hash_pos[1] > -1
   extracted_url_parts <- sub("^/|/$", "", strsplit(url_path, split = "\\?|#!|#")[[1]])
   path <- ""
+  query <- NULL
 
   if (url_has_query & url_has_hash) {
     # Query string may appear before or after hash
@@ -99,7 +100,6 @@ parse_url_path <- function(url_path) {
       path <- extracted_url_parts[2]
     }
   } else if (!url_has_query & url_has_hash) {
-    query <- extracted_url_parts[3]
     path <- extracted_url_parts[2]
   } else {
     query <- extracted_url_parts[2]

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -30,6 +30,9 @@ test_that("test parse_url_path", {
   expect_equal(p$path, "foo")
   expect_equal(p$query$a, "1")
   expect_true(length(p$query$b) == 2)
+  p <- parse_url_path("?a=1&b=foo")
+  expect_equal(p$path, "")
+  expect_equal(p$query$b, "foo")
 })
 
 test_that("test valid_path", {

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -20,11 +20,16 @@ test_that("test route_link", {
 test_that("test parse_url_path", {
   p <- parse_url_path("?a=1&b=foo#!/")
   expect_error(parse_url_path())
+  expect_error(parse_url_path("www.foo.bar"))
   expect_equal(p$path, "")
   expect_equal(p$query$b, "foo")
   p <- parse_url_path("www.foo.bar/?a=1&b[1]=foo&b[2]=bar")
   expect_true(length(p$query$b) == 2)
   expect_equal(p$query$b[[2]], "bar")
+  p <- parse_url_path("/#!/foo?a=1&b[1]=foo&b[2]=bar")
+  expect_equal(p$path, "foo")
+  expect_equal(p$query$a, "1")
+  expect_true(length(p$query$b) == 2)
 })
 
 test_that("test valid_path", {


### PR DESCRIPTION
# Add support for urls with query strings following hashbang

Modify parse-url_path to support query strings following hashbang/path, i.e. urls of the form: 

``#!/bar?foo=baz``, rather than ``?foo=baz/#!/bar``.

This is in reference to #64.
