### PR TITLE
Stop rerendering the whole page everytime url is changed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shiny.router
 Type: Package
 Title: Basic Routing for Shiny Web Applications
-Version: 0.1.1
+Version: 0.1.1.9000
 Authors@R: c(person("Filip", "Stachura",
                     email = "filip@appsilon.com",
                     role = c("aut")),

--- a/R/router.R
+++ b/R/router.R
@@ -122,10 +122,10 @@ create_router_callback <- function(root, routes) {
     observeEvent(session$userData$shiny.router.page(), {
       page_path <- session$userData$shiny.router.page()$path
       log_msg("shiny.router main output. path: ", page_path)
-      shiny::removeUI("#page-wrapper")
+      shiny::removeUI("#router-page-content")
       shiny::insertUI(
-        "body", "afterBegin",
-        shiny::div(id = "page-wrapper", routes[[page_path]][["ui"]])
+        "#router-page-wrapper", "afterBegin",
+        shiny::div(id = "router-page-content", routes[[page_path]][["ui"]])
       )
     })
   }
@@ -184,7 +184,7 @@ router_ui <- function() {
         )
       )
     ),
-    tags$div(id = "page-wrapper")
+    tags$div(id = "router-page-wrapper")
   )
 }
 

--- a/R/router.R
+++ b/R/router.R
@@ -121,6 +121,7 @@ create_router_callback <- function(root, routes) {
 
     observeEvent(session$userData$shiny.router.page(), {
       page_path <- session$userData$shiny.router.page()$path
+      log_msg("shiny.router main output. path: ", page_path)
       shiny::removeUI("#page-wrapper")
       shiny::insertUI(
         "body", "afterBegin",

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -23,6 +23,7 @@ page <- function(title, content, table_id) {
 # Both sample pages.
 root_page <- page("Home page", "Welcome on sample routing page!", "table_one")
 other_page <- page("Some other page", "Lorem ipsum dolor sit amet.", "table_two")
+third_page <- div(menu, titlePanel("Third Page"))
 
 # Callbacks on the server side for
 # the sample pages
@@ -43,7 +44,7 @@ other_callback <- function(input, output, session) {
 router <- make_router(
   route("/", root_page, root_callback),
   route("other", other_page, other_callback),
-  route("third", other_page, NA)
+  route("third", third_page, NA)
 )
 
 # Creat output for our router in main UI of Shiny app.

--- a/examples/basic/app.R
+++ b/examples/basic/app.R
@@ -11,29 +11,29 @@ menu <- (
 )
 
 # This creates UI for each page.
-page <- function(title, content) {
+page <- function(title, content, table_id) {
   div(
     menu,
     titlePanel(title),
     p(content),
-    dataTableOutput("table")
+    dataTableOutput(table_id)
   )
 }
 
 # Both sample pages.
-root_page <- page("Home page", "Welcome on sample routing page!")
-other_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+root_page <- page("Home page", "Welcome on sample routing page!", "table_one")
+other_page <- page("Some other page", "Lorem ipsum dolor sit amet.", "table_two")
 
 # Callbacks on the server side for
 # the sample pages
 root_callback <- function(input, output, session) {
-  output$table <- renderDataTable({
+  output$table_one <- renderDataTable({
     data.frame(x = c(1, 2), y = c(3, 4))
   })
 }
 
 other_callback <- function(input, output, session) {
-  output$table <- renderDataTable({
+  output$table_two <- renderDataTable({
     data.frame(x = c(5, 6), y = c(7, 8))
   })
 }

--- a/examples/common_server_parameter.R
+++ b/examples/common_server_parameter.R
@@ -10,37 +10,30 @@ menu <- (
 )
 
 # This creates UI for each page.
-page <- function(title, content) {
+page <- function(title, content, counter_id) {
   div(
     menu,
     titlePanel(title),
     p(content),
-    textOutput("server_own_counter"),
-    textOutput("server_common_counter")
+    textOutput(counter_id)
   )
 }
 
 # Both sample pages.
-root_page <- page("Home page", "Welcome on sample routing page!")
-second_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+root_page <- page("Home page", "Welcome on sample routing page!", "root_counter")
+second_page <- page("Some other page", "Lorem ipsum dolor sit amet.", "second_counter")
 
 # Callbacks on the server side for
 # the sample pages
 root_callback <- function(input, output, session, value) {
-  output$server_own_counter <- renderText({
-    as.numeric(input$clicks_separate) ^ 2
-  })
-  output$server_common_counter <- renderText({
-    as.numeric(value())
+  output$root_counter <- renderText({
+    paste("Transformed value with square", as.numeric(value()) ^ 2)
   })
 }
 
 second_callback <- function(input, output, session, value) {
-  output$server_own_counter <- renderText({
-    as.numeric(input$clicks_separate) ^ 3
-  })
-  output$server_common_counter <- renderText({
-    as.numeric(value())
+  output$second_counter <- renderText({
+    paste("Transformed value with cube", as.numeric(value()) ^ 3)
   })
 }
 
@@ -52,16 +45,20 @@ router <- make_router(
 )
 
 # Creat output for our router in main UI of Shiny app.
-ui <- shinyUI(fluidPage(
-  shiny::actionButton("clicks_separate", "Each router callback counts me differently!"),
-  shiny::actionButton("clicks_common", "My counter is passed to both router callbacks!"),
+ui <- fluidPage(
+  shiny::actionButton("clicks_common", "Number of clicks is passed to both pages and processed differently."),
+  textOutput("real_number"),
   router_ui()
-))
+)
 
 # Plug router into Shiny server.
 server <- shinyServer(function(input, output, session) {
   common_counter <- reactive({
     input$clicks_common
+  })
+
+  output$real_counter <- renderText({
+    paste("Real value:", input$clicks_common)
   })
 
   router(input, output, session, value = common_counter)

--- a/examples/disable_bootstrap.R
+++ b/examples/disable_bootstrap.R
@@ -9,7 +9,7 @@ bootstrap_page <- fluidPage(
   ),
   sidebarLayout(
     sidebarPanel(
-      sliderInput("obs",
+      shiny::sliderInput("obs",
                   "Number of observations:",
                   min = 0,
                   max = 1000,
@@ -44,16 +44,13 @@ ui <- shinyUI(
 server <- shinyServer(function(input, output, session) {
   router(input, output, session)
 
-  output$url <- renderPrint(
-    get_query_param()
-  )
-
   output$distPlot <- renderPlot({
+    req(input$obs)
     hist(rnorm(input$obs))
   })
 
   output$dropdown <- renderUI({
-    dropdown("simple_dropdown", LETTERS, value = "A")
+    dropdown_input("simple_dropdown", LETTERS, value = "A")
   })
 
   output$selected_letter <- renderText(input[["simple_dropdown"]])

--- a/examples/get_params.R
+++ b/examples/get_params.R
@@ -43,7 +43,7 @@ server <- shinyServer(function(input, output, session) {
     get_query_param()
   )
   observeEvent(input$button, {
-    change_page("?a=2#other")
+    change_page("other?a=2")
   })
 
 })

--- a/examples/semanticui/app.R
+++ b/examples/semanticui/app.R
@@ -15,8 +15,8 @@ menu <- (
     div(class = "item",
       div(class = "header", "Demo"),
       div(class = "menu",
-        a(class = "item", href = route_link("index"), uiicon("home"), "Page"),
-        a(class = "item", href = route_link("other"), uiicon("clock"), "Other")
+        a(class = "item", href = route_link("index"), icon("home"), "Page"),
+        a(class = "item", href = route_link("other"), icon("clock"), "Other")
       )
     )
   )
@@ -40,7 +40,7 @@ page <- function(title, content) {
 }
 
 root_page <- page("Home page", "Welcome on sample routing page!")
-other_page <- page("Some other page", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+other_page <- page("Some other page", "Lorem ipsum dolor sit amet.")
 
 router <- make_router(
   route("index", root_page),
@@ -52,8 +52,8 @@ ui <- shinyUI(semanticPage(
   router_ui()
 ))
 
-server <- shinyServer(function(input, output) {
-  router(input, output)
+server <- shinyServer(function(input, output, session) {
+  router(input, output, session)
 })
 
 shinyApp(ui, server)

--- a/examples/server_overwrite/app.R
+++ b/examples/server_overwrite/app.R
@@ -55,8 +55,10 @@ ui <- shinyUI(fluidPage(
 ))
 
 # Plug router into Shiny server.
-server <- shinyServer(function(input, output) {
-  router(input, output)
+server <- shinyServer(function(input, output, session) {
+  router(input, output, session)
+
+  # page callback are run at first, so the below code will overwrite click_me logic
   output$click_me <- renderText({
     as.numeric(input$clicks)
   })


### PR DESCRIPTION
Closes #71 #67 #65 
Makes #70 deprecated
Should also fix #69 

Previously, when the page was changed the whole UI and server code were executed from scratch.
This caused for example multiple registrations of observe events, more to that this was inefficient.

In this change, we stop running the whole server inside a single `renderUI` function.
Instead, we run page callback on application runtime, more to that `renderUI` was replaced with `insertUI/removeUI` what makes the workflow much faster.
