### PR TITLE
Fix losing subpath from chained url

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -51,7 +51,7 @@ extract_link_name <- function(path) {
 #' @examples
 #' route_link("abc") # /#!/abc
 route_link <- function(path) {
-  paste0("./", cleanup_hashpath(path))
+  paste0("/", cleanup_hashpath(path))
 }
 
 ########################### To export
@@ -68,7 +68,7 @@ route_link <- function(path) {
 #' }
 #' @details
 #' \code{parse_url_path} allows parsing paramaters lists from url. See more in examples.
-#' 
+#'
 #' Note that having query string appear before \code{#!} may cause browser to refresh
 #' and thus reset Shiny session.
 #' @export

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -13,8 +13,8 @@ test_that("test extract_link_name", {
 })
 
 test_that("test route_link", {
-  expect_equal(route_link("abc"), "./#!/abc")
-  expect_equal(route_link("#/xyzq"), "./#!/xyzq")
+  expect_equal(route_link("abc"), "/#!/abc")
+  expect_equal(route_link("#/xyzq"), "/#!/xyzq")
 })
 
 test_that("test parse_url_path", {
@@ -57,3 +57,4 @@ test_that("test get_query_param parameters", {
   expect_equal(shiny::isolate(get_query_param(session =  session)),
                list(one = 1, two = 2))
 })
+


### PR DESCRIPTION
# Fix losing subpath from chained url

Solves: https://github.com/Appsilon/shiny.router/issues/68 