### PR TITLE
Force hiding all child elements with .router-hidden

### DIFF
--- a/inst/www/shiny.router.css
+++ b/inst/www/shiny.router.css
@@ -7,5 +7,5 @@
 }
 
 .router-hidden * {
-  visibility: inherit;
+  visibility: inherit!important;
 }


### PR DESCRIPTION
When a semantic-ui sidebar is set to `class="visible"` it overrides the properties inherited from `.router-hidden`. 

In my case this prevented me from seeing the changes of the `active` menu items when navigating between pages. 