### PR TITLE
Add missing url in pkgdown configuration.

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -5,6 +5,8 @@ template:
   bslib:
     pkgdown-nav-height: 100px
 
+url: https://appsilon.github.io/shiny.router/
+
 navbar:
   bg: primary
   left:


### PR DESCRIPTION
URL is required by the search feature.
