### PR TITLE
Fix 404 issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shiny.router
 Type: Package
 Title: Basic Routing for Shiny Web Applications
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R:
   c(
     person("Ryszard", "Szymański", email = "opensource+ryszard@appsilon.com", role = c("cre", "aut")),

--- a/R/router.R
+++ b/R/router.R
@@ -123,7 +123,7 @@ create_router_callback <- function(root, routes = NULL) {
       ignoreInit = FALSE,
       # Shiny uses the "onhashchange" browser method (via JQuery) to detect
       # changes to the hash
-      eventExpr = c(get_url_hash(session), session$clientData$url_search),
+      eventExpr = c(get_url_hash(session), session$clientData$url_search, input$routes),
       handlerExpr = {
         log_msg("hashchange observer triggered!")
         new_hash <- shiny::getUrlHash(session)
@@ -141,6 +141,7 @@ create_router_callback <- function(root, routes = NULL) {
         parsed$path <- ifelse(parsed$path == "", root, parsed$path)
 
         is_path_valid <- if (is.null(routes)) {
+          shiny::req(input$routes)
           log_msg("Valid paths:", input$routes)
           !is.null(input$routes) && !(parsed$path %in% c(input$routes, "404"))
         } else {


### PR DESCRIPTION
# Fix 404 page not working when a non-valid page is opened as the first

Closes #124 

Test application:
```
#Shiny Router 0.3.0 ----------
options(shiny.port = 3333)
library(shiny.router)
library(shiny)

router <- router_ui(
  route("/", shiny::tags$div(shiny::tags$span("Hello world"))),
  route("main", shiny::tags$div(h1("Main page"), p("Lorem ipsum."))),
  page_404 = page404(tags$div(tags$h1("This is the 404 Page")))
)

shinyApp(
  router,
  function(input, output, session) {router_server()}
)

# 1. Visit http://localhost:3333/#!/non-existing-page directly (without ever visiting homepage) from your browser
# 2. Visit http://localhost:3333/#!/ first and then visit http://localhost:3333/#!/non-existing-page
```