### PR TITLE
replace dataset calls in vignettes with box imports

### DIFF
--- a/vignettes/rhino.Rmd
+++ b/vignettes/rhino.Rmd
@@ -186,6 +186,7 @@ The last step is to update `app/main.R`:
 
 box::use(
   shiny[bootstrapPage, moduleServer, NS],
+  rhino[rhinos],
 )
 
 box::use(
@@ -206,9 +207,8 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    # Datasets are the only case when you need to use :: in `box`.
-    # This issue should be solved in the next `box` release.
-    data <- rhino::rhinos
+    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+    data <- rhinos
 
     table$server("table", data = data)
     chart$server("chart", data = data)
@@ -314,6 +314,7 @@ The first argument there is the route where the UI will be placed
 box::use(
   shiny[bootstrapPage, moduleServer, NS],
   shiny.router[router_ui, router_server, route]
+  rhino[rhinos],
 )
 
 box::use(
@@ -338,9 +339,8 @@ server <- function(id) {
   moduleServer(id, function(input, output, session) {
     router_server("table")
 
-    # Datasets are the only case when you need to use :: in `box`.
-    # This issue should be solved in the next `box` release.
-    data <- rhino::rhinos
+    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+    data <- rhinos
 
     table$server("table", data = data)
     chart$server("chart", data = data)
@@ -481,6 +481,7 @@ A new view has to be added to our application - modify `app/main.R`:
 box::use(
   shiny[a, fluidPage, moduleServer, tags, NS],
   shiny.router[router_ui, router_server, route, route_link],
+  rhino[rhinos],
 )
 
 box::use(
@@ -522,9 +523,8 @@ server <- function(id) {
   moduleServer(id, function(input, output, session) {
     router_server("/")
 
-    # Datasets are the only case when you need to use :: in `box`.
-    # This issue should be solved in the next `box` release.
-    data <- rhino::rhinos
+    # Note : If you are using `box>=1.1.3`, import datasets directly without using `rhino::rhinos`
+    data <- rhinos
 
     intro$server("intro")
     table$server("table", data = data)


### PR DESCRIPTION
In vignettes, dataset calls follow the :: pattern due to a bug in the box package. Since the bug has been fixed and the new version of box is available on CRAN, all :: calls should be replaced with the proper box import.

Changes

- replaced dataset calls in rhino tutorials with box imports