### PR TITLE
137-fix-bug-with-plotly-inside-router

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     glue,
     rlang,
     shiny
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Suggests:
     covr,
     lintr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# development version
+
+- Fixed an issue where plots and cards were not fillable when using `shiny.router` with `bslib::page_fillable`. A `fill` argument was added to `router_ui` to control whether fill classes are added.
+- Fixed errors in tests by ensuring `js_file` and `css_file` are defined within the `router_ui` function scope.
+
 # shiny.router 0.3.1
 
 - Changed the dots (`...`) argument in `router_ui()` to allow dynamically passing of arguments. Now, its possible to pass routes in dynamic way with dynamic dots (`...`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # development version
 
-- Fixed an issue where plots and cards were not fillable when using `shiny.router` with `bslib::page_fillable`. A `fill` argument was added to `router_ui` to control whether fill classes are added.
+- Fixed an issue where plots and cards were not `fillable` when using `shiny.router` with `bslib::page_fillable`. A `fill` argument was added to `router_ui` to control whether fill classes are added.
 - Fixed errors in tests by ensuring `js_file` and `css_file` are defined within the `router_ui` function scope.
 
 # shiny.router 0.3.1

--- a/R/router.R
+++ b/R/router.R
@@ -187,6 +187,7 @@ create_router_callback <- function(root, routes = NULL) {
 #'   It's possible to pass routes in dynamic way with dynamic dots.
 #'   See \code{\link[rlang:dots_list]{dynamic-dots}} and example below
 #' @param page_404 Styling of page when invalid route is open. See \link{page404}.
+#' @param fill Whether to fill the container. Defaults to TRUE.
 #' @param env Environment (only for advanced usage), makes it possible to use shiny.router inside
 #'   shiny modules.
 #'
@@ -225,7 +226,7 @@ create_router_callback <- function(root, routes = NULL) {
 #'   }
 #' }
 #' @export
-router_ui <- function(default, ..., page_404 = page404(), env = parent.frame()) {
+router_ui <- function(default, ..., page_404 = page404(), fill = TRUE, env = parent.frame()) {
   args <- rlang::list2(...)
   if (!is.null(names(args))) {
     warning(
@@ -250,13 +251,45 @@ router_ui <- function(default, ..., page_404 = page404(), env = parent.frame()) 
 
   routes_names <- paste0("'", names(routes), "'", collapse = ", ")
 
+  fill_class <- if (isTRUE(fill)) {
+    "html-fill-item html-fill-container"
+  } else {
+    ""
+  }
+
+  shiny::addResourcePath(
+    "shiny.router",
+    system.file("www", package = "shiny.router")
+  )
+  js_file <- file.path("shiny.router", "shiny.router.js")
+  css_file <- file.path("shiny.router", "shiny.router.css")
+
   shiny::tagList(
     shiny::tags$script(
       glue::glue("$(document).on('shiny:connected', function() {{
         Shiny.setInputValue('{routes_input_id}', [{routes_names}]);
       }});")
     ),
-    router_ui_internal(router)
+    shiny::tags$div(
+      id = "router-page-wrapper",
+      class = fill_class,
+      lapply(router$routes, function(route) {
+        shiny::tagList(
+          shiny::div(
+            class = fill_class,
+            route$ui
+          )
+        )
+      })
+    ),
+    shiny::singleton(
+      shiny::withTags(
+        shiny::tags$head(
+          shiny::tags$script(type = "text/javascript", src = js_file),
+          shiny::tags$link(rel = "stylesheet", href = css_file)
+        )
+      )
+    )
   )
 }
 

--- a/man/router_ui.Rd
+++ b/man/router_ui.Rd
@@ -4,7 +4,13 @@
 \alias{router_ui}
 \title{Create router UI}
 \usage{
-router_ui(default, ..., page_404 = page404(), env = parent.frame())
+router_ui(
+  default,
+  ...,
+  page_404 = page404(),
+  fill = TRUE,
+  env = parent.frame()
+)
 }
 \arguments{
 \item{default}{Main route to which all invalid routes should redirect.}
@@ -14,6 +20,8 @@ It's possible to pass routes in dynamic way with dynamic dots.
 See \code{\link[rlang:dots_list]{dynamic-dots}} and example below}
 
 \item{page_404}{Styling of page when invalid route is open. See \link{page404}.}
+
+\item{fill}{Whether to fill the container. Defaults to TRUE.}
 
 \item{env}{Environment (only for advanced usage), makes it possible to use shiny.router inside
 shiny modules.}

--- a/shiny.router.Rproj
+++ b/shiny.router.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 3efa60cd-0392-45ca-bca6-249630c954d3
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Fixes #137 

This PR was an experiment using Copilot. See our knowledge base for more details.

## Description
- Fixed an issue where plots and cards were not `fillable` when using `shiny.router` with `bslib::page_fillable`. A `fill` argument was added to `router_ui` to control whether fill classes are added.
- Fixed errors in tests by ensuring `js_file` and `css_file` are defined within the `router_ui` function scope.
